### PR TITLE
Memory exhaustion fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var Stream = require('stream');
 var gutil = require('gulp-util');
 var _ = require('lodash');
 
-
 var PLUGIN_NAME = 'gulp-cordova-app-loader-manifest';
 
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 
 var Stream = require('stream');
 var gutil = require('gulp-util');
+var _ = require('lodash');
+
 
 var PLUGIN_NAME = 'gulp-cordova-app-loader-manifest';
 
@@ -19,7 +21,7 @@ var calManifest = function calManifest(options) {
 
     var manifest = {
         files: {},
-        load: options.load,
+        load: _.cloneDeep(options.load),
         root: options.root || './'
     };
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var calManifest = function calManifest(options) {
 
     var manifest = {
         files: {},
-        load: _.cloneDeep(options.load),
+        load: _.clone(options.load),
         root: options.root || './'
     };
 


### PR DESCRIPTION
## Goal

To fix the memory exhaustion problem which often is characterized by the terminal message
`Allocation failed - process out of memory`
## The cause

```
 var manifest = {
        files: {},
        load: options.load,
        root: options.root || './'
    };
```

here options is this object containing a load array, now manifest.load is a reference to the options.load array. So now in the loop 

```
 for (i = 0; i < options.load.length; i++) {
            pattern = options.load[i];
            if (pattern.indexOf(filename) > -1) {
                manifest.load.push(pattern.split(options.prefixSplit).pop())
            }
        }
```

manifest.load is pushing an element to itself which increases the length options.load ( since both are the same thing) increasing the length of the iteration. The new element causes the conditional to pass every time, which pushes the same element hence the iterative loop becomes an infinite one.
